### PR TITLE
fix: nil pointer on download error

### DIFF
--- a/internal/generate/source.go
+++ b/internal/generate/source.go
@@ -160,7 +160,7 @@ func (h *SourceHelper) getReleaseByVersion(version string) (*github.RepositoryRe
 
 	release, resp, err := client.Repositories.GetReleaseByTag(context.Background(), h.GithubOwner, h.GithubRepo, tagName)
 	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return nil, fmt.Errorf("no github release found with tag '%s'", tagName)
 		}
 		return nil, err


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/cli/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
Fixes a nil pointer exception when the download fails, as we were trying to reference the response in our error handling, which can be nil.